### PR TITLE
wrap/unwrap numbers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,8 +20,8 @@ defmodule Rational.Mixfile do
 
 
   defp deps do
-    [{:ex_doc, github: "elixir-lang/ex_doc"},
-     {:earmark, ">= 0.0.0"}]
+    [{:ex_doc, github: "elixir-lang/ex_doc", only: :dev},
+     {:earmark, ">= 0.0.0", only: :dev}]
   end
 
   defp description do


### PR DESCRIPTION
This makes it easier to work with a mixture of integers, floats and `%Rational{}`s.

There's a `value/1` function now that returns the floating point value for a given input.

I've also added an implementation of the `Inspect` protocol so it's easier to read in iex (I kept getting the `den` and `num` mixed up).

In addition, I've enabled native compilation (if available), which should speed things up quite a bit if you're crunching numbers.
